### PR TITLE
Added illustration to explain relationship between a REPL, REBL, and your editor\client

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ REBL runs in your application JVM process, and can be used at dev-time without a
 
 <p align="center"
 	
-![clojure_repl_rebl](https://user-images.githubusercontent.com/590297/50367997-631fdb00-0552-11e9-8f18-660dca9a62c8.png)
+![clojure_repl_rebl](https://user-images.githubusercontent.com/590297/50369932-61aedc80-056b-11e9-889b-ae95c86ea5a8.png)
 
 </p>
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,14 @@ REBL runs in your application JVM process, and can be used at dev-time without a
 
 </p>
 
-- Start your REPL or run REBL as your REPL with `clj -m congitect.rebl`
-- Send Clojure forms to your REPL manually, from your client or editor, or the REBL evaluation window
-- Inspect the evaluation results and navigate through nested data structures within the REBL UI.
+## How do I connect my editor to REBL?
+
+- REBL provides a REPL you can use with REBL via `clj -A rebl -m cognitect.rebl`
+- You can connect your editor to REBL by running the REBL command-line REPL with JVM socket server arguments.
+- Your editor can also communicate with your REBL REPL by running it as an inferior process inside your editor.
+
+## What about other network REPLs?
+- For nREPL or similar you will need to use middleware to communicate with the REBL UI. However, this approach has drawbacks due to the format of data sent across the wire. It is recommended to use the REBL command-line REPL for best results.
 
 ## Release Status
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ REBL is a graphical, interactive tool for browsing Clojure data. REBL is extract
 
 REBL runs in your application JVM process, and can be used at dev-time without adding any runtime deps. The UI is written in JavaFX.
 
+<p align="center"
+	
+  ![clojure_repl_rebl](https://user-images.githubusercontent.com/590297/50367582-361df900-054f-11e9-90c0-0c5d03e61d31.png)
+
+</p>
+
+- Start your REPL or run REBL as your REPL with `clj -m congitect.rebl`
+- Send Clojure forms to your REPL manually, from your client or editor, or the REBL evaluation window
+- Inspect the evaluation results and navigate through nested data structures within the REBL UI.
+
 ## Release Status
 
 REBL is early access. Your feedback can help make it better. Please report any [issues](https://github.com/cognitect-labs/REBL-distro/issues) that you encounter.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ REBL runs in your application JVM process, and can be used at dev-time without a
 
 <p align="center"
 	
-  ![clojure_repl_rebl](https://user-images.githubusercontent.com/590297/50367582-361df900-054f-11e9-90c0-0c5d03e61d31.png)
+![clojure_repl_rebl](https://user-images.githubusercontent.com/590297/50367997-631fdb00-0552-11e9-8f18-660dca9a62c8.png)
 
 </p>
 


### PR DESCRIPTION
# Problem

After setting up a couple example repos I've seen confusion around the relationship between  the REPL, REBL, and an editor\repl client.

## Solution

- Show that you connect to the REBL CLI REPL. You don't directly connect your editor to the REBL tool itself.
- Created a stylized illustration to show the relationship between a cli REPL, REBL, and an editor.
- Used entirely open source fonts and icons from the [DejaVu Sans Mono Nerd Font](https://github.com/ryanoasis/nerd-fonts/tree/master/patched-fonts/DejaVuSansMono)
- Added supported copy accompanying illustration

![clojure_repl_rebl](https://user-images.githubusercontent.com/590297/50369932-61aedc80-056b-11e9-889b-ae95c86ea5a8.png)

<p align="center">
<em>(proportions are smaller in this PR container than the README.md)</em>
</p>

Changes can be previewed at https://github.com/cognitect-labs/REBL-distro/blob/f0eb07c437a3c502b5ce1716742698d759fadefd/README.md

## Notes
- If any changes are required I am happy to make them upon request.
- I can provide the .ai illustrator source file as well in addition to SVG or PDF formats.