### PR TITLE
Remove tap> caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ REBL is a graphical, interactive tool for browsing Clojure data. REBL is extract
 * Extensibility to new browsers and viewers
 * Full keyboard control via [hotkeys](https://github.com/cognitect-labs/REBL-distro/wiki/Hotkeys)
 
-### NOTE - tap> is not currently wired up in the UI.
-
 ![screenshot](screenshot.png)
 
 REBL runs in your application JVM process, and can be used at dev-time without adding any runtime deps. The UI is written in JavaFX.


### PR DESCRIPTION
Since `tap>` is now working -- even on OpenJDK 11!